### PR TITLE
Fix altEnd value in ModLoader/HeightColorMap.cs

### DIFF
--- a/Kopernicus/Configuration/ModLoader/HeightColorMap.cs
+++ b/Kopernicus/Configuration/ModLoader/HeightColorMap.cs
@@ -72,7 +72,7 @@ namespace Kopernicus
 					[ParserTarget("altitudeEnd")]
 					private NumericParser<double> altitudeEnd
 					{
-						set { landClass.altStart = value.value; }
+						set { landClass.altEnd = value.value; }
 					}
 
 					// Should we blend into the next class


### PR DESCRIPTION
altitudeEnd and altitudeStart were both setting altStart internally, which made it so that only one land class showed up in game no matter what you did in the config.
